### PR TITLE
doc create swagger auto documentation

### DIFF
--- a/app/trees_everywhere/settings.py
+++ b/app/trees_everywhere/settings.py
@@ -39,6 +39,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'core',
+    'rest_framework',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -128,3 +130,7 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'core.User'
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}

--- a/app/trees_everywhere/urls.py
+++ b/app/trees_everywhere/urls.py
@@ -13,9 +13,19 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView,
+)
 from django.contrib import admin
 from django.urls import path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/schema/', SpectacularAPIView.as_view(), name='api-schema'),
+    path(
+        'api/docs/',
+        SpectacularSwaggerView.as_view(url_name='api-schema'),
+        name='api-docs',
+    )
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=4.0.4,<4.1
 djangorestframework>=3.13.1,<3.14
 psycopg2>=2.9.3,<2.10
+drf-spectacular>=0.22.1,<0.23


### PR DESCRIPTION
## What?
Adding automated `API` documentation.

## Why?
It's fundamental to have proper `Documentation` related to the `API` usage.

## How?
Using the `Django Rest Framework` alongside with `drf_spectacular`, the `API`
documentation is auto-generated.
